### PR TITLE
🐛 Fix impossible type hints

### DIFF
--- a/src/MessageWrapper.php
+++ b/src/MessageWrapper.php
@@ -43,7 +43,7 @@ trait MessageWrapper
         return $this->getMessage()->getProtocolVersion();
     }
 
-    public function withProtocolVersion(string $version): MessageInterface
+    public function withProtocolVersion($version): MessageInterface
     {
         return $this->viaFactory($this->getMessage()->withProtocolVersion($version));
     }
@@ -53,32 +53,32 @@ trait MessageWrapper
         return $this->getMessage()->getHeaders();
     }
 
-    public function hasHeader(string $name): bool
+    public function hasHeader($name): bool
     {
         return $this->getMessage()->hasHeader($name);
     }
 
-    public function getHeader(string $name): array
+    public function getHeader($name): array
     {
         return $this->getMessage()->getHeader($name);
     }
 
-    public function getHeaderLine(string $name): string
+    public function getHeaderLine($name): string
     {
         return $this->getMessage()->getHeaderLine($name);
     }
 
-    public function withHeader(string $name, $value): MessageInterface
+    public function withHeader($name, $value): MessageInterface
     {
         return $this->viaFactory($this->getMessage()->withHeader($name, $value));
     }
 
-    public function withAddedHeader(string $name, $value): MessageInterface
+    public function withAddedHeader($name, $value): MessageInterface
     {
         return $this->viaFactory($this->getMessage()->withAddedHeader($name, $value));
     }
 
-    public function withoutHeader(string $name): MessageInterface
+    public function withoutHeader($name): MessageInterface
     {
         return $this->viaFactory($this->getMessage()->withoutHeader($name));
     }

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -40,7 +40,7 @@ trait RequestWrapper
         return $this->getMessage()->getMethod();
     }
 
-    public function withMethod(string $method): RequestInterface
+    public function withMethod($method): RequestInterface
     {
         return $this->viaFactory($this->getMessage()->withMethod($method));
     }
@@ -50,7 +50,7 @@ trait RequestWrapper
         return $this->getMessage()->getUri();
     }
 
-    public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface
+    public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
     {
         return $this->viaFactory($this->getMessage()->withUri($uri, $preserveHost));
     }

--- a/src/ResponseWrapper.php
+++ b/src/ResponseWrapper.php
@@ -29,7 +29,7 @@ trait ResponseWrapper
         return $this->getMessage()->getStatusCode();
     }
 
-    public function withStatus(int $code, string $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = '')
     {
         return $this->viaFactory($this->getMessage()->withStatus($code, $reasonPhrase));
     }

--- a/src/ServerRequestWrapper.php
+++ b/src/ServerRequestWrapper.php
@@ -74,17 +74,17 @@ trait ServerRequestWrapper
         return $this->getMessage()->getAttributes();
     }
 
-    public function getAttribute(string $name, $default = null)
+    public function getAttribute($name, $default = null)
     {
         return $this->getMessage()->getAttribute($name, $default);
     }
 
-    public function withAttribute(string $name, $value)
+    public function withAttribute($name, $value)
     {
         return $this->viaFactory($this->getMessage()->withAttribute($name, $value));
     }
 
-    public function withoutAttribute(string $name)
+    public function withoutAttribute($name)
     {
         return $this->viaFactory($this->getMessage()->withoutAttribute($name));
     }

--- a/test/Fixture/MessageWrapperFixture.php
+++ b/test/Fixture/MessageWrapperFixture.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message\Fixture;
 use PhoneBurner\Http\Message\MessageWrapper;
 use Psr\Http\Message\MessageInterface;
 
-class MessageWrapperFixture
+class MessageWrapperFixture implements MessageInterface
 {
     use MessageWrapper;
 

--- a/test/Fixture/RequestWrapperFixture.php
+++ b/test/Fixture/RequestWrapperFixture.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message\Fixture;
 use PhoneBurner\Http\Message\RequestWrapper;
 use Psr\Http\Message\RequestInterface;
 
-class RequestWrapperFixture
+class RequestWrapperFixture implements RequestInterface
 {
     use RequestWrapper;
 

--- a/test/Fixture/ResponseWrapperFixture.php
+++ b/test/Fixture/ResponseWrapperFixture.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message\Fixture;
 use PhoneBurner\Http\Message\ResponseWrapper;
 use Psr\Http\Message\ResponseInterface;
 
-class ResponseWrapperFixture
+class ResponseWrapperFixture implements ResponseInterface
 {
     use ResponseWrapper;
 

--- a/test/Fixture/ServerRequestWrapperFixture.php
+++ b/test/Fixture/ServerRequestWrapperFixture.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message\Fixture;
 use PhoneBurner\Http\Message\ServerRequestWrapper;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ServerRequestWrapperFixture
+class ServerRequestWrapperFixture implements ServerRequestInterface
 {
     use ServerRequestWrapper;
 


### PR DESCRIPTION
Our fixtures didn't actually implement the interface, so test didn't catch our aggressive type declarations.