### PR TITLE
Add Missing Wrappers

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -3,7 +3,6 @@
 namespace PhoneBurner\Http\Message;
 
 use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UriInterface;
 
 trait StreamWrapper
 {

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PhoneBurner\Http\Message;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+trait StreamWrapper
+{
+    private $stream;
+
+    protected function setStream(StreamInterface $stream)
+    {
+        $this->stream = $stream;
+    }
+
+    private function getStream(): StreamInterface
+    {
+        if (!($this->stream instanceof StreamInterface)) {
+            throw new \UnexpectedValueException('must `setUri` before using it');
+        }
+
+        return $this->stream;
+    }
+
+    public function __toString()
+    {
+        return $this->getStream()->__toString();
+    }
+
+    public function close(): void
+    {
+        $this->getStream()->close();;
+    }
+
+    public function detach()
+    {
+        return $this->getStream()->detach();
+    }
+
+    public function getSize(): ?int
+    {
+        return $this->getStream()->getSize();
+    }
+
+    public function tell(): int
+    {
+        return $this->getStream()->tell();
+    }
+
+    public function eof(): bool
+    {
+        return $this->getStream()->eof();
+    }
+
+    public function isSeekable(): bool
+    {
+        return $this->getStream()->isSeekable();
+    }
+
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        return $this->getStream()->seek($offset, $whence);
+    }
+
+    public function rewind()
+    {
+        return $this->getStream()->rewind();
+    }
+
+    public function isWritable(): bool
+    {
+        return $this->getStream()->isWritable();
+    }
+
+    public function write($string): int
+    {
+        return $this->getStream()->write($string);
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->getStream()->isReadable();
+    }
+
+    public function read($length): string
+    {
+        return $this->getStream()->read($length);
+    }
+
+    public function getContents(): string
+    {
+        return $this->getStream()->getContents();
+    }
+
+    public function getMetadata($key = null)
+    {
+        return $this->getStream()->getMetadata($key);
+    }
+}

--- a/src/UploadedFileWrapper.php
+++ b/src/UploadedFileWrapper.php
@@ -5,7 +5,7 @@ namespace PhoneBurner\Http\Message;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-trait UploadWrapper
+trait UploadedFileWrapper
 {
     private $file;
 

--- a/src/UriWrapper.php
+++ b/src/UriWrapper.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace PhoneBurner\Http\Message;
+
+use Psr\Http\Message\UriInterface;
+
+trait UriWrapper
+{
+    private $uri;
+    private $uriFactory;
+
+    protected function setFactory(callable $factory)
+    {
+        $this->uriFactory = $factory;
+    }
+
+    private function viaFactory(UriInterface $uri)
+    {
+        if (!$this->uriFactory) {
+            return $uri;
+        }
+
+        return call_user_func($this->uriFactory, $uri);
+    }
+
+    protected function setUri(UriInterface $uri)
+    {
+        $this->uri = $uri;
+    }
+
+    private function getUri(): UriInterface
+    {
+        if (!($this->uri instanceof UriInterface)) {
+            throw new \UnexpectedValueException('must `setUri` before using it');
+        }
+
+        return $this->uri;
+    }
+
+    public function getScheme(): string
+    {
+        return $this->getUri()->getScheme();
+    }
+
+    public function getAuthority(): string
+    {
+        return $this->getUri()->getAuthority();
+    }
+
+    public function getUserInfo(): string
+    {
+        return $this->getUri()->getUserInfo();
+    }
+
+    public function getHost(): string
+    {
+        return $this->getUri()->getHost();
+    }
+
+    public function getPort(): ?int
+    {
+        return $this->getUri()->getPort();
+    }
+
+    public function getPath(): string
+    {
+        return $this->getUri()->getPath();
+    }
+
+    public function getQuery(): string
+    {
+        return $this->getUri()->getQuery();
+    }
+
+    public function getFragment(): string
+    {
+        return $this->getUri()->getFragment();
+    }
+
+    public function withScheme($scheme): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withScheme($scheme));
+    }
+
+    public function withUserInfo($user, $password = null): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withUserInfo($user, $password));
+    }
+
+    public function withHost($host): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withHost($host));
+    }
+
+    public function withPort($port): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withPort($port));
+    }
+
+    public function withPath($path): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withPath($path));
+    }
+
+    public function withQuery($query): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withQuery($query));
+    }
+
+    public function withFragment($fragment): UriInterface
+    {
+        return $this->viaFactory($this->getUri()->withFragment($fragment));
+    }
+
+    public function __toString(): string
+    {
+        return $this->getUri()->__toString();
+    }
+}

--- a/test/DataProvider/MessageDataProvider.php
+++ b/test/DataProvider/MessageDataProvider.php
@@ -6,13 +6,13 @@ use Psr\Http\Message\StreamInterface;
 
 trait MessageDataProvider
 {
-    public function provideAllMethods(): \Generator
+    public function provideAllMethods(): iterable
     {
         yield from $this->provideWithMethods();
         yield from $this->provideGetterMethods();
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield "getProtocolVersion() => '1.1'" => ['getProtocolVersion', [], '1.1'];
         yield "getProtocolVersion() => '1.0'" => ['getProtocolVersion', [], '1.0'];
@@ -39,7 +39,7 @@ trait MessageDataProvider
         yield "getBody()" => ['getBody', [], $body];
     }
 
-    public function provideWithMethods(): \Generator
+    public function provideWithMethods(): iterable
     {
         yield "withProtocolVersion('1.1')" => ['withProtocolVersion', ['1.1']];
         yield "withProtocolVersion('1.0')" => ['withProtocolVersion', ['1.0']];

--- a/test/DataProvider/RequestDataProvider.php
+++ b/test/DataProvider/RequestDataProvider.php
@@ -2,7 +2,6 @@
 
 namespace PhoneBurnerTest\Http\Message\DataProvider;
 
-use PhoneBurnerTest\Http\Message\DataProvider\MessageDataProvider;
 use Psr\Http\Message\UriInterface;
 
 trait RequestDataProvider
@@ -12,7 +11,7 @@ trait RequestDataProvider
         provideWithMethods as provideMessageWithMethods;
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield from $this->provideMessageGetterMethods();
 
@@ -28,7 +27,7 @@ trait RequestDataProvider
         yield "getUri()" => ['getUri', [], $uri];
     }
 
-    public function provideWithMethods(): \Generator
+    public function provideWithMethods(): iterable
     {
         yield from $this->provideMessageWithMethods();
 

--- a/test/DataProvider/ResponseDataProvider.php
+++ b/test/DataProvider/ResponseDataProvider.php
@@ -2,9 +2,6 @@
 
 namespace PhoneBurnerTest\Http\Message\DataProvider;
 
-use PhoneBurnerTest\Http\Message\DataProvider\MessageDataProvider;
-use Psr\Http\Message\UriInterface;
-
 trait ResponseDataProvider
 {
     use MessageDataProvider {
@@ -12,7 +9,7 @@ trait ResponseDataProvider
         provideWithMethods as provideMessageWithMethods;
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield from $this->provideMessageGetterMethods();
 
@@ -21,7 +18,7 @@ trait ResponseDataProvider
         yield "getReasonPhrase() => 'OK'" => ['getReasonPhrase', [], 'OK'];
     }
 
-    public function provideWithMethods(): \Generator
+    public function provideWithMethods(): iterable
     {
         yield from $this->provideMessageWithMethods();
 

--- a/test/DataProvider/ServerRequestDataProvider.php
+++ b/test/DataProvider/ServerRequestDataProvider.php
@@ -2,7 +2,6 @@
 
 namespace PhoneBurnerTest\Http\Message\DataProvider;
 
-use PhoneBurnerTest\Http\Message\DataProvider\RequestDataProvider;
 use Psr\Http\Message\UploadedFileInterface;
 
 trait ServerRequestDataProvider
@@ -12,7 +11,7 @@ trait ServerRequestDataProvider
         provideWithMethods as provideRequestWithMethods;
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield from $this->provideRequestGetterMethods();
 
@@ -57,7 +56,7 @@ trait ServerRequestDataProvider
         yield "getAttribute('obj', 'test')" => ['getAttribute', ['user', 'test'], 'test'];
     }
 
-    public function provideWithMethods(): \Generator
+    public function provideWithMethods(): iterable
     {
         yield from $this->provideRequestWithMethods();
 

--- a/test/EvolvingWrapperTestCase.php
+++ b/test/EvolvingWrapperTestCase.php
@@ -25,7 +25,7 @@ abstract class EvolvingWrapperTestCase extends WrapperTestCase
         $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
         $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertSame($return, $sut->$method(...$args));
+        self::assertSame($return, $sut->$method(...$args));
     }
 
     /**
@@ -53,6 +53,6 @@ abstract class EvolvingWrapperTestCase extends WrapperTestCase
             return $wrapped;
         });
 
-        $this->assertSame($wrapped, $sut->$method(...$args));
+        self::assertSame($wrapped, $sut->$method(...$args));
     }
 }

--- a/test/EvolvingWrapperTestCase.php
+++ b/test/EvolvingWrapperTestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PhoneBurnerTest\Http\Message;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class EvolvingWrapperTestCase extends WrapperTestCase
+{
+    abstract public function provideWithMethods(): \Generator;
+
+    /**
+     * @test
+     * @dataProvider provideWithMethods
+     */
+    public function withMethodsAreProxied(string $method, array $args, array $expected = null): void
+    {
+        // allow expected args to differ from the args we pass the wrapper
+        // but if they're not defined, they are the same as what is passed to
+        // the wrapper
+        if (null === $expected) {
+            $expected = $args;
+        }
+
+        $fixture_class = static::FIXTURE_CLASS;
+        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
+        $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $this->assertSame($return, $sut->$method(...$args));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideWithMethods
+     */
+    public function withMethodsUseFactoryWhenProvided($method, $args, array $expected = null): void
+    {
+        // allow expected args to differ from the args we pass the wrapper
+        // but if they're not defined, they are the same as what is passed to
+        // the wrapper
+        if (null === $expected) {
+            $expected = $args;
+        }
+
+        $fixture_class = static::FIXTURE_CLASS;
+
+        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
+        $wrapped = $this->prophesize(static::FIXTURE_CLASS)->reveal();
+
+        $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
+
+        $sut = new $fixture_class($this->mocked_wrapped->reveal(), function ($message) use ($return, $wrapped) {
+            TestCase::assertSame($return, $message);
+            return $wrapped;
+        });
+
+        $this->assertSame($wrapped, $sut->$method(...$args));
+    }
+}

--- a/test/EvolvingWrapperTestCase.php
+++ b/test/EvolvingWrapperTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class EvolvingWrapperTestCase extends WrapperTestCase
 {
-    abstract public function provideWithMethods(): \Generator;
+    abstract public function provideWithMethods(): iterable;
 
     /**
      * @test

--- a/test/Fixture/StreamWrapperFixture.php
+++ b/test/Fixture/StreamWrapperFixture.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhoneBurnerTest\Http\Message\Fixture;
+
+use PhoneBurner\Http\Message\StreamWrapper;
+use Psr\Http\Message\StreamInterface;
+
+class StreamWrapperFixture implements StreamInterface
+{
+    use StreamWrapper;
+
+    public function __construct(StreamInterface $stream = null)
+    {
+        if (null !== $stream) {
+            $this->setStream($stream);
+        }
+    }
+}

--- a/test/Fixture/UploadedFileWrapperFixture.php
+++ b/test/Fixture/UploadedFileWrapperFixture.php
@@ -2,12 +2,12 @@
 
 namespace PhoneBurnerTest\Http\Message\Fixture;
 
-use PhoneBurner\Http\Message\UploadWrapper;
+use PhoneBurner\Http\Message\UploadedFileWrapper;
 use Psr\Http\Message\UploadedFileInterface;
 
-class UploadedFileFixture implements UploadedFileInterface
+class UploadedFileWrapperFixture implements UploadedFileInterface
 {
-    use UploadWrapper;
+    use UploadedFileWrapper;
 
     public function __construct(UploadedFileInterface $file = null)
     {

--- a/test/Fixture/UriWrapperFixture.php
+++ b/test/Fixture/UriWrapperFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PhoneBurnerTest\Http\Message\Fixture;
+
+use PhoneBurner\Http\Message\UriWrapper;
+use Psr\Http\Message\UriInterface;
+
+class UriWrapperFixture implements UriInterface
+{
+    use UriWrapper;
+
+    public function __construct(UriInterface $uri = null, callable $factory = null)
+    {
+        if (null !== $uri) {
+            $this->setUri($uri);
+        }
+
+        if (null !== $factory) {
+            $this->setFactory($factory);
+        }
+    }
+}

--- a/test/MessageWrapperTest.php
+++ b/test/MessageWrapperTest.php
@@ -6,7 +6,7 @@ use PhoneBurnerTest\Http\Message\DataProvider\MessageDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\MessageWrapperFixture;
 use Psr\Http\Message\MessageInterface;
 
-class MessageWrapperTest extends WrapperTestCase
+class MessageWrapperTest extends EvolvingWrapperTestCase
 {
     use MessageDataProvider;
 

--- a/test/MessageWrapperTest.php
+++ b/test/MessageWrapperTest.php
@@ -4,14 +4,12 @@ namespace PhoneBurnerTest\Http\Message;
 
 use PhoneBurnerTest\Http\Message\DataProvider\MessageDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\MessageWrapperFixture;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
 
-class MessageWrapperTest extends TestCase
+class MessageWrapperTest extends WrapperTestCase
 {
     use MessageDataProvider;
-    use CommonWrapperTests;
 
-    private const WRAPPED_CLASS = MessageInterface::class;
-    private const FIXTURE_CLASS = MessageWrapperFixture::class;
+    protected const WRAPPED_CLASS = MessageInterface::class;
+    protected const FIXTURE_CLASS = MessageWrapperFixture::class;
 }

--- a/test/RequestWrapperTest.php
+++ b/test/RequestWrapperTest.php
@@ -6,7 +6,7 @@ use PhoneBurnerTest\Http\Message\DataProvider\RequestDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\RequestWrapperFixture;
 use Psr\Http\Message\RequestInterface;
 
-class RequestWrapperTest extends WrapperTestCase
+class RequestWrapperTest extends EvolvingWrapperTestCase
 {
     use RequestDataProvider;
 

--- a/test/RequestWrapperTest.php
+++ b/test/RequestWrapperTest.php
@@ -4,14 +4,12 @@ namespace PhoneBurnerTest\Http\Message;
 
 use PhoneBurnerTest\Http\Message\DataProvider\RequestDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\RequestWrapperFixture;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
-class RequestWrapperTest extends TestCase
+class RequestWrapperTest extends WrapperTestCase
 {
     use RequestDataProvider;
-    use CommonWrapperTests;
 
-    private const WRAPPED_CLASS = RequestInterface::class;
-    private const FIXTURE_CLASS = RequestWrapperFixture::class;
+    protected const WRAPPED_CLASS = RequestInterface::class;
+    protected const FIXTURE_CLASS = RequestWrapperFixture::class;
 }

--- a/test/ResponseWrapperTest.php
+++ b/test/ResponseWrapperTest.php
@@ -6,7 +6,7 @@ use PhoneBurnerTest\Http\Message\DataProvider\ResponseDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\ResponseWrapperFixture;
 use Psr\Http\Message\ResponseInterface;
 
-class ResponseWrapperTest extends WrapperTestCase
+class ResponseWrapperTest extends EvolvingWrapperTestCase
 {
     use ResponseDataProvider;
 

--- a/test/ResponseWrapperTest.php
+++ b/test/ResponseWrapperTest.php
@@ -5,13 +5,11 @@ namespace PhoneBurnerTest\Http\Message;
 use PhoneBurnerTest\Http\Message\DataProvider\ResponseDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\ResponseWrapperFixture;
 use Psr\Http\Message\ResponseInterface;
-use PHPUnit\Framework\TestCase;
 
-class ResponseWrapperTest extends TestCase
+class ResponseWrapperTest extends WrapperTestCase
 {
     use ResponseDataProvider;
-    use CommonWrapperTests;
 
-    private const WRAPPED_CLASS = ResponseInterface::class;
-    private const FIXTURE_CLASS = ResponseWrapperFixture::class;
+    protected const WRAPPED_CLASS = ResponseInterface::class;
+    protected const FIXTURE_CLASS = ResponseWrapperFixture::class;
 }

--- a/test/ServerRequestWrapperTest.php
+++ b/test/ServerRequestWrapperTest.php
@@ -6,7 +6,7 @@ use PhoneBurnerTest\Http\Message\DataProvider\ServerRequestDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\ServerRequestWrapperFixture;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ServerRequestWrapperTest extends WrapperTestCase
+class ServerRequestWrapperTest extends EvolvingWrapperTestCase
 {
     use ServerRequestDataProvider;
 

--- a/test/ServerRequestWrapperTest.php
+++ b/test/ServerRequestWrapperTest.php
@@ -4,14 +4,12 @@ namespace PhoneBurnerTest\Http\Message;
 
 use PhoneBurnerTest\Http\Message\DataProvider\ServerRequestDataProvider;
 use PhoneBurnerTest\Http\Message\Fixture\ServerRequestWrapperFixture;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ServerRequestWrapperTest extends TestCase
+class ServerRequestWrapperTest extends WrapperTestCase
 {
     use ServerRequestDataProvider;
-    use CommonWrapperTests;
 
-    private const WRAPPED_CLASS = ServerRequestInterface::class;
-    private const FIXTURE_CLASS = ServerRequestWrapperFixture::class;
+    protected const WRAPPED_CLASS = ServerRequestInterface::class;
+    protected const FIXTURE_CLASS = ServerRequestWrapperFixture::class;
 }

--- a/test/StreamWrapperTest.php
+++ b/test/StreamWrapperTest.php
@@ -29,13 +29,13 @@ class StreamWrapperTest extends WrapperTestCase
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->detach()->shouldBeCalled()->willReturn(null);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertNull($sut->detach());
+        self::assertNull($sut->detach());
 
         $fixture_class = static::FIXTURE_CLASS;
         $resource = fopen('php://temp', 'r');
         $this->mocked_wrapped->detach()->shouldBeCalled()->willReturn($resource);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertSame($resource, $sut->detach());
+        self::assertSame($resource, $sut->detach());
         fclose($resource);
     }
 
@@ -78,7 +78,7 @@ class StreamWrapperTest extends WrapperTestCase
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->write('test')->willReturn(10);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertSame(10, $sut->write('test'));
+        self::assertSame(10, $sut->write('test'));
     }
 
     public function provideAllMethods(): \Generator

--- a/test/StreamWrapperTest.php
+++ b/test/StreamWrapperTest.php
@@ -13,7 +13,7 @@ class StreamWrapperTest extends WrapperTestCase
     /**
      * @test
      */
-    public function closeIsProxied()
+    public function closeIsProxied(): void
     {
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->close()->shouldBeCalled();
@@ -24,7 +24,7 @@ class StreamWrapperTest extends WrapperTestCase
     /**
      * @test
      */
-    public function detachIsProxied()
+    public function detachIsProxied(): void
     {
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->detach()->shouldBeCalled()->willReturn(null);
@@ -43,7 +43,7 @@ class StreamWrapperTest extends WrapperTestCase
      * @test
      * @dataProvider provideSeekArgs
      */
-    public function seekIsProxied($offset, $whence)
+    public function seekIsProxied($offset, $whence): void
     {
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->seek($offset, $whence)->shouldBeCalled();
@@ -51,7 +51,7 @@ class StreamWrapperTest extends WrapperTestCase
         $sut->seek($offset, $whence);
     }
 
-    public function provideSeekArgs()
+    public function provideSeekArgs(): iterable
     {
         yield [10, SEEK_CUR];
         yield [10, SEEK_END];
@@ -62,7 +62,7 @@ class StreamWrapperTest extends WrapperTestCase
     /**
      * @test
      */
-    public function rewindIsProxied()
+    public function rewindIsProxied(): void
     {
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->rewind()->shouldBeCalled();
@@ -73,7 +73,7 @@ class StreamWrapperTest extends WrapperTestCase
     /**
      * @test
      */
-    public function writeIsProxied()
+    public function writeIsProxied(): void
     {
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->write('test')->willReturn(10);
@@ -81,12 +81,12 @@ class StreamWrapperTest extends WrapperTestCase
         self::assertSame(10, $sut->write('test'));
     }
 
-    public function provideAllMethods(): \Generator
+    public function provideAllMethods(): iterable
     {
         yield from $this->provideGetterMethods();
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield "getSize (null)" => ['getSize', [], null];
         yield "getSize" => ['getSize', [], 100];

--- a/test/StreamWrapperTest.php
+++ b/test/StreamWrapperTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace PhoneBurnerTest\Http\Message;
+
+use PhoneBurnerTest\Http\Message\Fixture\StreamWrapperFixture;
+use Psr\Http\Message\StreamInterface;
+
+class StreamWrapperTest extends WrapperTestCase
+{
+    protected const WRAPPED_CLASS = StreamInterface::class;
+    protected const FIXTURE_CLASS = StreamWrapperFixture::class;
+
+    public function provideAllMethods(): \Generator
+    {
+        yield from $this->provideWithMethods();
+        yield from $this->provideGetterMethods();
+    }
+
+    /**
+     * @test
+     */
+    public function closeIsProxied()
+    {
+        $fixture_class = static::FIXTURE_CLASS;
+        $this->mocked_wrapped->close()->shouldBeCalled();
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $sut->close();
+    }
+
+    /**
+     * @test
+     */
+    public function detachIsProxied()
+    {
+        $fixture_class = static::FIXTURE_CLASS;
+        $this->mocked_wrapped->detach()->shouldBeCalled()->willReturn(null);
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $this->assertNull($sut->detach());
+
+        $fixture_class = static::FIXTURE_CLASS;
+        $resource = fopen('php://temp', 'r');
+        $this->mocked_wrapped->detach()->shouldBeCalled()->willReturn($resource);
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $this->assertSame($resource, $sut->detach());
+        fclose($resource);
+    }
+
+    /**
+     * @test
+     * @dataProvider provideSeekArgs
+     */
+    public function seekIsProxied($offset, $whence)
+    {
+        $fixture_class = static::FIXTURE_CLASS;
+        $this->mocked_wrapped->seek($offset, $whence)->shouldBeCalled();
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $sut->seek($offset, $whence);
+    }
+
+    public function provideSeekArgs()
+    {
+        yield [10, SEEK_CUR];
+        yield [10, SEEK_END];
+        yield [10, SEEK_SET];
+        yield [10, null];
+    }
+
+    /**
+     * @test
+     */
+    public function rewindIsProxied()
+    {
+        $fixture_class = static::FIXTURE_CLASS;
+        $this->mocked_wrapped->rewind()->shouldBeCalled();
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $sut->rewind();
+    }
+
+    /**
+     * @test
+     */
+    public function writeIsProxied()
+    {
+        $fixture_class = static::FIXTURE_CLASS;
+        $this->mocked_wrapped->write('test')->willReturn(10);
+        $sut = new $fixture_class($this->mocked_wrapped->reveal());
+        $this->assertSame(10, $sut->write('test'));
+    }
+
+    public function provideGetterMethods(): \Generator
+    {
+        yield "getSize (null)" => ['getSize', [], null];
+        yield "getSize" => ['getSize', [], 100];
+        yield "tell" => ['getSize', [], 10];
+        yield "eof (true)" => ['eof', [], true];
+        yield "eof (false)" => ['eof', [], false];
+        yield "isSeekable (false)" => ['isSeekable', [], false];
+        yield "isSeekable (true)" => ['isSeekable', [], true];
+        yield "isWritable (false)" => ['isWritable', [], false];
+        yield "isWritable (true)" => ['isWritable', [], true];
+        yield "isReadable (false)" => ['isReadable', [], false];
+        yield "isReadable (true)" => ['isReadable', [], true];
+        yield "read" => ['read', [10], 'test'];
+        yield "getContents" => ['getContents', [], 'content'];
+        yield "getMetadata (null)" => ['getMetadata', [null], ['key' => 'value']];
+        yield "getMetadata (key)" => ['getMetadata', ['key'], 'value'];
+        yield "getMetadata (invalid key)" => ['getMetadata', ['not_key'], null];
+        yield "__toString" => ['__toString', [], 'content'];
+    }
+
+    public function provideWithMethods(): \Generator
+    {
+        yield from [];
+    }
+}

--- a/test/StreamWrapperTest.php
+++ b/test/StreamWrapperTest.php
@@ -10,12 +10,6 @@ class StreamWrapperTest extends WrapperTestCase
     protected const WRAPPED_CLASS = StreamInterface::class;
     protected const FIXTURE_CLASS = StreamWrapperFixture::class;
 
-    public function provideAllMethods(): \Generator
-    {
-        yield from $this->provideWithMethods();
-        yield from $this->provideGetterMethods();
-    }
-
     /**
      * @test
      */
@@ -87,6 +81,11 @@ class StreamWrapperTest extends WrapperTestCase
         $this->assertSame(10, $sut->write('test'));
     }
 
+    public function provideAllMethods(): \Generator
+    {
+        yield from $this->provideGetterMethods();
+    }
+
     public function provideGetterMethods(): \Generator
     {
         yield "getSize (null)" => ['getSize', [], null];
@@ -106,10 +105,5 @@ class StreamWrapperTest extends WrapperTestCase
         yield "getMetadata (key)" => ['getMetadata', ['key'], 'value'];
         yield "getMetadata (invalid key)" => ['getMetadata', ['not_key'], null];
         yield "__toString" => ['__toString', [], 'content'];
-    }
-
-    public function provideWithMethods(): \Generator
-    {
-        yield from [];
     }
 }

--- a/test/UploadWrapperTest.php
+++ b/test/UploadWrapperTest.php
@@ -3,16 +3,13 @@
 namespace PhoneBurnerTest\Http\Message;
 
 use PhoneBurnerTest\Http\Message\Fixture\UploadedFileFixture;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-class UploadWrapperTest extends TestCase
+class UploadWrapperTest extends WrapperTestCase
 {
-    use CommonWrapperTests;
-
-    private const WRAPPED_CLASS = UploadedFileInterface::class;
-    private const FIXTURE_CLASS = UploadedFileFixture::class;
+    protected const WRAPPED_CLASS = UploadedFileInterface::class;
+    protected const FIXTURE_CLASS = UploadedFileFixture::class;
 
     /**
      * @test
@@ -69,7 +66,7 @@ class UploadWrapperTest extends TestCase
         yield from $this->provideGetterMethods();
     }
 
-    public function provideGetterMethods(): ?\Generator
+    public function provideGetterMethods(): \Generator
     {
         $stream = $this->prophesize(StreamInterface::class);
         yield "getStream()" => ['getStream', [], $stream->reveal()];
@@ -86,8 +83,8 @@ class UploadWrapperTest extends TestCase
         yield "getClientMediaType() => null" => ['getClientMediaType', [], null];
     }
 
-    public function provideWithMethods(): array
+    public function provideWithMethods(): \Generator
     {
-        return [];
+        yield from [];
     }
 }

--- a/test/UploadedFileWrapperTest.php
+++ b/test/UploadedFileWrapperTest.php
@@ -2,14 +2,14 @@
 
 namespace PhoneBurnerTest\Http\Message;
 
-use PhoneBurnerTest\Http\Message\Fixture\UploadedFileFixture;
+use PhoneBurnerTest\Http\Message\Fixture\UploadedFileWrapperFixture;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-class UploadWrapperTest extends WrapperTestCase
+class UploadedFileWrapperTest extends WrapperTestCase
 {
     protected const WRAPPED_CLASS = UploadedFileInterface::class;
-    protected const FIXTURE_CLASS = UploadedFileFixture::class;
+    protected const FIXTURE_CLASS = UploadedFileWrapperFixture::class;
 
     /**
      * @test

--- a/test/UploadedFileWrapperTest.php
+++ b/test/UploadedFileWrapperTest.php
@@ -43,7 +43,7 @@ class UploadedFileWrapperTest extends WrapperTestCase
         $this->mocked_wrapped->moveTo('path')->willReturn('something');
 
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertNull($sut->moveTo('path'));
+        self::assertNull($sut->moveTo('path'));
     }
 
     /**

--- a/test/UploadedFileWrapperTest.php
+++ b/test/UploadedFileWrapperTest.php
@@ -61,12 +61,12 @@ class UploadedFileWrapperTest extends WrapperTestCase
         $sut->moveTo('path');
     }
 
-    public function provideAllMethods(): \Generator
+    public function provideAllMethods(): iterable
     {
         yield from $this->provideGetterMethods();
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         $stream = $this->prophesize(StreamInterface::class);
         yield "getStream()" => ['getStream', [], $stream->reveal()];

--- a/test/UploadedFileWrapperTest.php
+++ b/test/UploadedFileWrapperTest.php
@@ -82,9 +82,4 @@ class UploadedFileWrapperTest extends WrapperTestCase
         yield "getClientMediaType() => 'type'" => ['getClientMediaType', [], 'type'];
         yield "getClientMediaType() => null" => ['getClientMediaType', [], null];
     }
-
-    public function provideWithMethods(): \Generator
-    {
-        yield from [];
-    }
 }

--- a/test/UriWrapperTest.php
+++ b/test/UriWrapperTest.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message;
 use PhoneBurnerTest\Http\Message\Fixture\UriWrapperFixture;
 use Psr\Http\Message\UriInterface;
 
-class UriWrapperTest extends WrapperTestCase
+class UriWrapperTest extends EvolvingWrapperTestCase
 {
     protected const WRAPPED_CLASS = UriInterface::class;
     protected const FIXTURE_CLASS = UriWrapperFixture::class;

--- a/test/UriWrapperTest.php
+++ b/test/UriWrapperTest.php
@@ -10,13 +10,13 @@ class UriWrapperTest extends EvolvingWrapperTestCase
     protected const WRAPPED_CLASS = UriInterface::class;
     protected const FIXTURE_CLASS = UriWrapperFixture::class;
 
-    public function provideAllMethods(): \Generator
+    public function provideAllMethods(): iterable
     {
         yield from $this->provideWithMethods();
         yield from $this->provideGetterMethods();
     }
 
-    public function provideGetterMethods(): \Generator
+    public function provideGetterMethods(): iterable
     {
         yield "getScheme" => ['getScheme', [], 'http'];
         yield "getAuthority (none)" => ['getAuthority', [], ''];
@@ -31,7 +31,7 @@ class UriWrapperTest extends EvolvingWrapperTestCase
         yield "__toString" => ['__toString', [], 'http://example.com/test'];
     }
 
-    public function provideWithMethods(): \Generator
+    public function provideWithMethods(): iterable
     {
         yield "withScheme" => ['withScheme', ['https']];
         yield "withUserInfo (user only)" => ['withUserInfo', ['nopass', null]];

--- a/test/UriWrapperTest.php
+++ b/test/UriWrapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PhoneBurnerTest\Http\Message;
+
+use PhoneBurnerTest\Http\Message\Fixture\UriWrapperFixture;
+use Psr\Http\Message\UriInterface;
+
+class UriWrapperTest extends WrapperTestCase
+{
+    protected const WRAPPED_CLASS = UriInterface::class;
+    protected const FIXTURE_CLASS = UriWrapperFixture::class;
+
+    public function provideAllMethods(): \Generator
+    {
+        yield from $this->provideWithMethods();
+        yield from $this->provideGetterMethods();
+    }
+
+    public function provideGetterMethods(): \Generator
+    {
+        yield "getScheme" => ['getScheme', [], 'http'];
+        yield "getAuthority (none)" => ['getAuthority', [], ''];
+        yield "getAuthority" => ['getAuthority', [], 'user:info@host:80'];
+        yield "getUserInfo" => ['getUserInfo', [], 'user:info'];
+        yield "getHost" => ['getHost', [], 'host'];
+        yield "getPort" => ['getPort', [], 80];
+        yield "getPort (null)" => ['getPort', [], null];
+        yield "getPath" => ['getPath', [], '/path'];
+        yield "getQuery" => ['getQuery', [], 'query'];
+        yield "getFragment" => ['getFragment', [], 'fragment'];
+        yield "__toString" => ['__toString', [], 'http://example.com/test'];
+    }
+
+    public function provideWithMethods(): \Generator
+    {
+        yield "withScheme" => ['withScheme', ['https']];
+        yield "withUserInfo (user only)" => ['withUserInfo', ['nopass', null]];
+        yield "withUserInfo (user and password)" => ['withUserInfo', ['with', 'pass']];
+        yield "withHost" => ['withHost', ['example.com']];
+        yield "withPort" => ['withPort', [8080]];
+        yield "withPort (null)" => ['withPort', [null]];
+        yield "withPath" => ['withPath', ['path']];
+        yield "withQuery" => ['withQuery', ['query']];
+        yield "withFragment" => ['withFragment', ['fragment']];
+    }
+}

--- a/test/WrapperTestCase.php
+++ b/test/WrapperTestCase.php
@@ -9,7 +9,6 @@ abstract class WrapperTestCase extends TestCase
 {
     abstract public function provideAllMethods(): \Generator;
     abstract public function provideGetterMethods(): \Generator;
-    abstract public function provideWithMethods(): \Generator;
 
     /**
      * @var ObjectProphecy
@@ -50,53 +49,5 @@ abstract class WrapperTestCase extends TestCase
         $this->mocked_wrapped->$method(...$expected)->willReturn($return);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
         $this->assertSame($return, $sut->$method(...$args));
-    }
-
-    /**
-     * @test
-     * @dataProvider provideWithMethods
-     */
-    public function withMethodsAreProxied(string $method, array $args, array $expected = null): void
-    {
-        // allow expected args to differ from the args we pass the wrapper
-        // but if they're not defined, they are the same as what is passed to
-        // the wrapper
-        if (null === $expected) {
-            $expected = $args;
-        }
-
-        $fixture_class = static::FIXTURE_CLASS;
-        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
-        $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
-        $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertSame($return, $sut->$method(...$args));
-    }
-
-    /**
-     * @test
-     * @dataProvider provideWithMethods
-     */
-    public function withMethodsUseFactoryWhenProvided($method, $args, array $expected = null): void
-    {
-        // allow expected args to differ from the args we pass the wrapper
-        // but if they're not defined, they are the same as what is passed to
-        // the wrapper
-        if (null === $expected) {
-            $expected = $args;
-        }
-
-        $fixture_class = static::FIXTURE_CLASS;
-
-        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
-        $wrapped = $this->prophesize(static::FIXTURE_CLASS)->reveal();
-
-        $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
-
-        $sut = new $fixture_class($this->mocked_wrapped->reveal(), function ($message) use ($return, $wrapped) {
-            TestCase::assertSame($return, $message);
-            return $wrapped;
-        });
-
-        $this->assertSame($wrapped, $sut->$method(...$args));
     }
 }

--- a/test/WrapperTestCase.php
+++ b/test/WrapperTestCase.php
@@ -7,8 +7,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 abstract class WrapperTestCase extends TestCase
 {
-    abstract public function provideAllMethods(): \Generator;
-    abstract public function provideGetterMethods(): \Generator;
+    abstract public function provideAllMethods(): iterable;
+    abstract public function provideGetterMethods(): iterable;
 
     /**
      * @var ObjectProphecy

--- a/test/WrapperTestCase.php
+++ b/test/WrapperTestCase.php
@@ -48,6 +48,6 @@ abstract class WrapperTestCase extends TestCase
         $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->$method(...$expected)->willReturn($return);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
-        $this->assertSame($return, $sut->$method(...$args));
+        self::assertSame($return, $sut->$method(...$args));
     }
 }

--- a/test/WrapperTestCase.php
+++ b/test/WrapperTestCase.php
@@ -88,7 +88,7 @@ abstract class WrapperTestCase extends TestCase
         $fixture_class = static::FIXTURE_CLASS;
 
         $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
-        $wrapped = $this->prophesize(static::WRAPPED_CLASS)->reveal();
+        $wrapped = $this->prophesize(static::FIXTURE_CLASS)->reveal();
 
         $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
 

--- a/test/WrapperTestCase.php
+++ b/test/WrapperTestCase.php
@@ -5,7 +5,7 @@ namespace PhoneBurnerTest\Http\Message;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 
-trait CommonWrapperTests
+abstract class WrapperTestCase extends TestCase
 {
     abstract public function provideAllMethods(): \Generator;
     abstract public function provideGetterMethods(): \Generator;
@@ -14,11 +14,11 @@ trait CommonWrapperTests
     /**
      * @var ObjectProphecy
      */
-    private $mocked_wrapped;
+    protected $mocked_wrapped;
 
     public function setUp(): void
     {
-        $this->mocked_wrapped = $this->prophesize(self::WRAPPED_CLASS);
+        $this->mocked_wrapped = $this->prophesize(static::WRAPPED_CLASS);
     }
 
     /**
@@ -27,7 +27,7 @@ trait CommonWrapperTests
      */
     public function proxiedMethodsRequireWrappedClass($method, $args): void
     {
-        $fixture_class = self::FIXTURE_CLASS;
+        $fixture_class = static::FIXTURE_CLASS;
         $sut = new $fixture_class();
         $this->expectException(\UnexpectedValueException::class);
         $sut->$method(...$args);
@@ -46,7 +46,7 @@ trait CommonWrapperTests
             $expected = $args;
         }
 
-        $fixture_class = self::FIXTURE_CLASS;
+        $fixture_class = static::FIXTURE_CLASS;
         $this->mocked_wrapped->$method(...$expected)->willReturn($return);
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
         $this->assertSame($return, $sut->$method(...$args));
@@ -65,8 +65,8 @@ trait CommonWrapperTests
             $expected = $args;
         }
 
-        $fixture_class = self::FIXTURE_CLASS;
-        $return = $this->prophesize(self::WRAPPED_CLASS)->reveal();
+        $fixture_class = static::FIXTURE_CLASS;
+        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
         $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
         $sut = new $fixture_class($this->mocked_wrapped->reveal());
         $this->assertSame($return, $sut->$method(...$args));
@@ -85,10 +85,10 @@ trait CommonWrapperTests
             $expected = $args;
         }
 
-        $fixture_class = self::FIXTURE_CLASS;
+        $fixture_class = static::FIXTURE_CLASS;
 
-        $return = $this->prophesize(self::WRAPPED_CLASS)->reveal();
-        $wrapped = $this->prophesize(self::WRAPPED_CLASS)->reveal();
+        $return = $this->prophesize(static::WRAPPED_CLASS)->reveal();
+        $wrapped = $this->prophesize(static::WRAPPED_CLASS)->reveal();
 
         $this->mocked_wrapped->$method(...$expected)->willReturn($return)->shouldBeCalled();
 


### PR DESCRIPTION
Adds wrappers for `StreamInterface` and `UriInterface`, also improves the tests a bit by moving from a trait to abstract test case classes, and (since we're now testing two interfaces that have no `with*()` methods), splits testing of the factory into a seperate test case class. 