### PR TITLE
Unify Method Names

### DIFF
--- a/src/MessageWrapper.php
+++ b/src/MessageWrapper.php
@@ -7,89 +7,89 @@ use Psr\Http\Message\StreamInterface;
 
 trait MessageWrapper
 {
-    private $message;
-    private $messageFactory;
+    private $wrapped;
+    private $factory;
 
     protected function setFactory(callable $factory)
     {
-        $this->messageFactory = $factory;
+        $this->factory = $factory;
     }
 
     private function viaFactory(MessageInterface $message)
     {
-        if (!$this->messageFactory) {
+        if (!$this->factory) {
             return $message;
         }
 
-        return call_user_func($this->messageFactory, $message);
+        return call_user_func($this->factory, $message);
     }
 
-    protected function setMessage(MessageInterface $message)
+    protected function setWrapped(MessageInterface $message)
     {
-        $this->message = $message;
+        $this->wrapped = $message;
     }
 
-    private function getMessage(): MessageInterface
+    private function getWrapped(): MessageInterface
     {
-        if (!($this->message instanceof MessageInterface)) {
+        if (!($this->wrapped instanceof MessageInterface)) {
             throw new \UnexpectedValueException('must `setMessage` before using it');
         }
 
-        return $this->message;
+        return $this->wrapped;
     }
 
     public function getProtocolVersion(): string
     {
-        return $this->getMessage()->getProtocolVersion();
+        return $this->getWrapped()->getProtocolVersion();
     }
 
     public function withProtocolVersion($version): MessageInterface
     {
-        return $this->viaFactory($this->getMessage()->withProtocolVersion($version));
+        return $this->viaFactory($this->getWrapped()->withProtocolVersion($version));
     }
 
     public function getHeaders(): array
     {
-        return $this->getMessage()->getHeaders();
+        return $this->getWrapped()->getHeaders();
     }
 
     public function hasHeader($name): bool
     {
-        return $this->getMessage()->hasHeader($name);
+        return $this->getWrapped()->hasHeader($name);
     }
 
     public function getHeader($name): array
     {
-        return $this->getMessage()->getHeader($name);
+        return $this->getWrapped()->getHeader($name);
     }
 
     public function getHeaderLine($name): string
     {
-        return $this->getMessage()->getHeaderLine($name);
+        return $this->getWrapped()->getHeaderLine($name);
     }
 
     public function withHeader($name, $value): MessageInterface
     {
-        return $this->viaFactory($this->getMessage()->withHeader($name, $value));
+        return $this->viaFactory($this->getWrapped()->withHeader($name, $value));
     }
 
     public function withAddedHeader($name, $value): MessageInterface
     {
-        return $this->viaFactory($this->getMessage()->withAddedHeader($name, $value));
+        return $this->viaFactory($this->getWrapped()->withAddedHeader($name, $value));
     }
 
     public function withoutHeader($name): MessageInterface
     {
-        return $this->viaFactory($this->getMessage()->withoutHeader($name));
+        return $this->viaFactory($this->getWrapped()->withoutHeader($name));
     }
 
     public function getBody(): StreamInterface
     {
-        return $this->getMessage()->getBody();
+        return $this->getWrapped()->getBody();
     }
 
     public function withBody(StreamInterface $body): MessageInterface
     {
-        return $this->viaFactory($this->getMessage()->withBody($body));
+        return $this->viaFactory($this->getWrapped()->withBody($body));
     }
 }

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -9,49 +9,49 @@ trait RequestWrapper
 {
     use MessageWrapper;
 
-    private $message;
+    private $wrapped;
 
-    protected function setMessage(RequestInterface $message): void
+    protected function setWrapped(RequestInterface $message): void
     {
-        $this->message = $message;
+        $this->wrapped = $message;
     }
 
-    private function getMessage(): RequestInterface
+    private function getWrapped(): RequestInterface
     {
-        if (!($this->message instanceof RequestInterface)) {
+        if (!($this->wrapped instanceof RequestInterface)) {
             throw new \UnexpectedValueException('must `setRequest` before using it');
         }
 
-        return $this->message;
+        return $this->wrapped;
     }
 
     public function getRequestTarget(): string
     {
-        return $this->getMessage()->getRequestTarget();
+        return $this->getWrapped()->getRequestTarget();
     }
 
     public function withRequestTarget($requestTarget): RequestInterface
     {
-        return $this->viaFactory($this->getMessage()->withRequestTarget($requestTarget));
+        return $this->viaFactory($this->getWrapped()->withRequestTarget($requestTarget));
     }
 
     public function getMethod(): string
     {
-        return $this->getMessage()->getMethod();
+        return $this->getWrapped()->getMethod();
     }
 
     public function withMethod($method): RequestInterface
     {
-        return $this->viaFactory($this->getMessage()->withMethod($method));
+        return $this->viaFactory($this->getWrapped()->withMethod($method));
     }
 
     public function getUri(): UriInterface
     {
-        return $this->getMessage()->getUri();
+        return $this->getWrapped()->getUri();
     }
 
     public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
     {
-        return $this->viaFactory($this->getMessage()->withUri($uri, $preserveHost));
+        return $this->viaFactory($this->getWrapped()->withUri($uri, $preserveHost));
     }
 }

--- a/src/ResponseWrapper.php
+++ b/src/ResponseWrapper.php
@@ -8,34 +8,34 @@ trait ResponseWrapper
 {
     use MessageWrapper;
 
-    private $message;
+    private $wrapped;
 
-    protected function setMessage(ResponseInterface $message): void
+    protected function setWrapped(ResponseInterface $message): void
     {
-        $this->message = $message;
+        $this->wrapped = $message;
     }
 
-    private function getMessage(): ResponseInterface
+    private function getWrapped(): ResponseInterface
     {
-        if (!($this->message instanceof ResponseInterface)) {
+        if (!($this->wrapped instanceof ResponseInterface)) {
             throw new \UnexpectedValueException('must `setRequest` before using it');
         }
 
-        return $this->message;
+        return $this->wrapped;
     }
 
     public function getStatusCode(): int
     {
-        return $this->getMessage()->getStatusCode();
+        return $this->getWrapped()->getStatusCode();
     }
 
     public function withStatus($code, $reasonPhrase = '')
     {
-        return $this->viaFactory($this->getMessage()->withStatus($code, $reasonPhrase));
+        return $this->viaFactory($this->getWrapped()->withStatus($code, $reasonPhrase));
     }
 
     public function getReasonPhrase(): string
     {
-        return $this->getMessage()->getReasonPhrase();
+        return $this->getWrapped()->getReasonPhrase();
     }
 }

--- a/src/ServerRequestWrapper.php
+++ b/src/ServerRequestWrapper.php
@@ -8,84 +8,84 @@ trait ServerRequestWrapper
 {
     use RequestWrapper;
 
-    private $message;
+    private $wrapped;
 
-    protected function setMessage(ServerRequestInterface $message): void
+    protected function setWrapped(ServerRequestInterface $message): void
     {
-        $this->message = $message;
+        $this->wrapped = $message;
     }
 
-    private function getMessage(): ServerRequestInterface
+    private function getWrapped(): ServerRequestInterface
     {
-        if (!($this->message instanceof ServerRequestInterface)) {
+        if (!($this->wrapped instanceof ServerRequestInterface)) {
             throw new \UnexpectedValueException('must `setMessage` before using it');
         }
 
-        return $this->message;
+        return $this->wrapped;
     }
 
     public function getServerParams()
     {
-        return $this->getMessage()->getServerParams();
+        return $this->getWrapped()->getServerParams();
     }
 
     public function getCookieParams()
     {
-        return $this->getMessage()->getCookieParams();
+        return $this->getWrapped()->getCookieParams();
     }
 
     public function withCookieParams(array $cookies)
     {
-        return $this->viaFactory($this->getMessage()->withCookieParams($cookies));
+        return $this->viaFactory($this->getWrapped()->withCookieParams($cookies));
     }
 
     public function getQueryParams()
     {
-        return $this->getMessage()->getQueryParams();
+        return $this->getWrapped()->getQueryParams();
     }
 
     public function withQueryParams(array $query)
     {
-        return $this->viaFactory($this->getMessage()->withQueryParams($query));
+        return $this->viaFactory($this->getWrapped()->withQueryParams($query));
     }
 
     public function getUploadedFiles()
     {
-        return $this->getMessage()->getUploadedFiles();
+        return $this->getWrapped()->getUploadedFiles();
     }
 
     public function withUploadedFiles(array $uploadedFiles)
     {
-        return $this->viaFactory($this->getMessage()->withUploadedFiles($uploadedFiles));
+        return $this->viaFactory($this->getWrapped()->withUploadedFiles($uploadedFiles));
     }
 
     public function getParsedBody()
     {
-        return $this->getMessage()->getParsedBody();
+        return $this->getWrapped()->getParsedBody();
     }
 
     public function withParsedBody($data)
     {
-        return $this->viaFactory($this->getMessage()->withParsedBody($data));
+        return $this->viaFactory($this->getWrapped()->withParsedBody($data));
     }
 
     public function getAttributes()
     {
-        return $this->getMessage()->getAttributes();
+        return $this->getWrapped()->getAttributes();
     }
 
     public function getAttribute($name, $default = null)
     {
-        return $this->getMessage()->getAttribute($name, $default);
+        return $this->getWrapped()->getAttribute($name, $default);
     }
 
     public function withAttribute($name, $value)
     {
-        return $this->viaFactory($this->getMessage()->withAttribute($name, $value));
+        return $this->viaFactory($this->getWrapped()->withAttribute($name, $value));
     }
 
     public function withoutAttribute($name)
     {
-        return $this->viaFactory($this->getMessage()->withoutAttribute($name));
+        return $this->viaFactory($this->getWrapped()->withoutAttribute($name));
     }
 }

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -6,94 +6,94 @@ use Psr\Http\Message\StreamInterface;
 
 trait StreamWrapper
 {
-    private $stream;
+    private $wrapped;
 
-    protected function setStream(StreamInterface $stream)
+    protected function setWrapped(StreamInterface $stream)
     {
-        $this->stream = $stream;
+        $this->wrapped = $stream;
     }
 
-    private function getStream(): StreamInterface
+    private function getWrapped(): StreamInterface
     {
-        if (!($this->stream instanceof StreamInterface)) {
+        if (!($this->wrapped instanceof StreamInterface)) {
             throw new \UnexpectedValueException('must `setUri` before using it');
         }
 
-        return $this->stream;
+        return $this->wrapped;
     }
 
     public function __toString()
     {
-        return $this->getStream()->__toString();
+        return $this->getWrapped()->__toString();
     }
 
     public function close(): void
     {
-        $this->getStream()->close();;
+        $this->getWrapped()->close();;
     }
 
     public function detach()
     {
-        return $this->getStream()->detach();
+        return $this->getWrapped()->detach();
     }
 
     public function getSize(): ?int
     {
-        return $this->getStream()->getSize();
+        return $this->getWrapped()->getSize();
     }
 
     public function tell(): int
     {
-        return $this->getStream()->tell();
+        return $this->getWrapped()->tell();
     }
 
     public function eof(): bool
     {
-        return $this->getStream()->eof();
+        return $this->getWrapped()->eof();
     }
 
     public function isSeekable(): bool
     {
-        return $this->getStream()->isSeekable();
+        return $this->getWrapped()->isSeekable();
     }
 
     public function seek($offset, $whence = SEEK_SET)
     {
-        return $this->getStream()->seek($offset, $whence);
+        return $this->getWrapped()->seek($offset, $whence);
     }
 
     public function rewind()
     {
-        return $this->getStream()->rewind();
+        return $this->getWrapped()->rewind();
     }
 
     public function isWritable(): bool
     {
-        return $this->getStream()->isWritable();
+        return $this->getWrapped()->isWritable();
     }
 
     public function write($string): int
     {
-        return $this->getStream()->write($string);
+        return $this->getWrapped()->write($string);
     }
 
     public function isReadable(): bool
     {
-        return $this->getStream()->isReadable();
+        return $this->getWrapped()->isReadable();
     }
 
     public function read($length): string
     {
-        return $this->getStream()->read($length);
+        return $this->getWrapped()->read($length);
     }
 
     public function getContents(): string
     {
-        return $this->getStream()->getContents();
+        return $this->getWrapped()->getContents();
     }
 
     public function getMetadata($key = null)
     {
-        return $this->getStream()->getMetadata($key);
+        return $this->getWrapped()->getMetadata($key);
     }
 }

--- a/src/UploadedFileWrapper.php
+++ b/src/UploadedFileWrapper.php
@@ -7,49 +7,49 @@ use Psr\Http\Message\UploadedFileInterface;
 
 trait UploadedFileWrapper
 {
-    private $file;
+    private $wrapped;
 
-    private function setUploadedFile(UploadedFileInterface $file)
+    private function setWrapped(UploadedFileInterface $file)
     {
-        $this->file = $file;
+        $this->wrapped = $file;
     }
 
-    private function getUploadedFile(): UploadedFileInterface
+    private function getWrapped(): UploadedFileInterface
     {
-        if (!($this->file instanceof UploadedFileInterface)) {
+        if (!($this->wrapped instanceof UploadedFileInterface)) {
             throw new \UnexpectedValueException('must `setUploadedFile` before using it');
         }
 
-        return $this->file;
+        return $this->wrapped;
     }
 
     public function getStream(): StreamInterface
     {
-        return $this->getUploadedFile()->getStream();
+        return $this->getWrapped()->getStream();
     }
 
     public function moveTo($targetPath): void
     {
-        $this->getUploadedFile()->moveTo($targetPath);
+        $this->getWrapped()->moveTo($targetPath);
     }
 
     public function getSize(): ?int
     {
-        return $this->getUploadedFile()->getSize();
+        return $this->getWrapped()->getSize();
     }
 
     public function getError(): int
     {
-        return $this->getUploadedFile()->getError();
+        return $this->getWrapped()->getError();
     }
 
     public function getClientFilename(): ?string
     {
-        return $this->getUploadedFile()->getClientFilename();
+        return $this->getWrapped()->getClientFilename();
     }
 
     public function getClientMediaType(): ?string
     {
-        return $this->getUploadedFile()->getClientMediaType();
+        return $this->getWrapped()->getClientMediaType();
     }
 }

--- a/src/UriWrapper.php
+++ b/src/UriWrapper.php
@@ -6,114 +6,114 @@ use Psr\Http\Message\UriInterface;
 
 trait UriWrapper
 {
-    private $uri;
-    private $uriFactory;
+    private $wrapped;
+    private $factory;
 
     protected function setFactory(callable $factory)
     {
-        $this->uriFactory = $factory;
+        $this->factory = $factory;
     }
 
     private function viaFactory(UriInterface $uri)
     {
-        if (!$this->uriFactory) {
+        if (!$this->factory) {
             return $uri;
         }
 
-        return call_user_func($this->uriFactory, $uri);
+        return call_user_func($this->factory, $uri);
     }
 
-    protected function setUri(UriInterface $uri)
+    protected function setWrapped(UriInterface $uri)
     {
-        $this->uri = $uri;
+        $this->wrapped = $uri;
     }
 
-    private function getUri(): UriInterface
+    private function getWrapped(): UriInterface
     {
-        if (!($this->uri instanceof UriInterface)) {
+        if (!($this->wrapped instanceof UriInterface)) {
             throw new \UnexpectedValueException('must `setUri` before using it');
         }
 
-        return $this->uri;
+        return $this->wrapped;
     }
 
     public function getScheme(): string
     {
-        return $this->getUri()->getScheme();
+        return $this->getWrapped()->getScheme();
     }
 
     public function getAuthority(): string
     {
-        return $this->getUri()->getAuthority();
+        return $this->getWrapped()->getAuthority();
     }
 
     public function getUserInfo(): string
     {
-        return $this->getUri()->getUserInfo();
+        return $this->getWrapped()->getUserInfo();
     }
 
     public function getHost(): string
     {
-        return $this->getUri()->getHost();
+        return $this->getWrapped()->getHost();
     }
 
     public function getPort(): ?int
     {
-        return $this->getUri()->getPort();
+        return $this->getWrapped()->getPort();
     }
 
     public function getPath(): string
     {
-        return $this->getUri()->getPath();
+        return $this->getWrapped()->getPath();
     }
 
     public function getQuery(): string
     {
-        return $this->getUri()->getQuery();
+        return $this->getWrapped()->getQuery();
     }
 
     public function getFragment(): string
     {
-        return $this->getUri()->getFragment();
+        return $this->getWrapped()->getFragment();
     }
 
     public function withScheme($scheme): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withScheme($scheme));
+        return $this->viaFactory($this->getWrapped()->withScheme($scheme));
     }
 
     public function withUserInfo($user, $password = null): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withUserInfo($user, $password));
+        return $this->viaFactory($this->getWrapped()->withUserInfo($user, $password));
     }
 
     public function withHost($host): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withHost($host));
+        return $this->viaFactory($this->getWrapped()->withHost($host));
     }
 
     public function withPort($port): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withPort($port));
+        return $this->viaFactory($this->getWrapped()->withPort($port));
     }
 
     public function withPath($path): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withPath($path));
+        return $this->viaFactory($this->getWrapped()->withPath($path));
     }
 
     public function withQuery($query): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withQuery($query));
+        return $this->viaFactory($this->getWrapped()->withQuery($query));
     }
 
     public function withFragment($fragment): UriInterface
     {
-        return $this->viaFactory($this->getUri()->withFragment($fragment));
+        return $this->viaFactory($this->getWrapped()->withFragment($fragment));
     }
 
     public function __toString(): string
     {
-        return $this->getUri()->__toString();
+        return $this->getWrapped()->__toString();
     }
 }

--- a/test/Fixture/MessageWrapperFixture.php
+++ b/test/Fixture/MessageWrapperFixture.php
@@ -12,7 +12,7 @@ class MessageWrapperFixture implements MessageInterface
     public function __construct(MessageInterface $message = null, callable $factory = null)
     {
         if (null !== $message) {
-            $this->setMessage($message);
+            $this->setWrapped($message);
         }
 
         if (null !== $factory) {

--- a/test/Fixture/RequestWrapperFixture.php
+++ b/test/Fixture/RequestWrapperFixture.php
@@ -12,7 +12,7 @@ class RequestWrapperFixture implements RequestInterface
     public function __construct(RequestInterface $request = null, callable $factory = null)
     {
         if (null !== $request) {
-            $this->setMessage($request);
+            $this->setWrapped($request);
         }
 
         if (null !== $factory) {

--- a/test/Fixture/ResponseWrapperFixture.php
+++ b/test/Fixture/ResponseWrapperFixture.php
@@ -12,7 +12,7 @@ class ResponseWrapperFixture implements ResponseInterface
     public function __construct(ResponseInterface $response = null, callable $factory = null)
     {
         if (null !== $response) {
-            $this->setMessage($response);
+            $this->setWrapped($response);
         }
 
         if (null !== $factory) {

--- a/test/Fixture/ServerRequestWrapperFixture.php
+++ b/test/Fixture/ServerRequestWrapperFixture.php
@@ -12,7 +12,7 @@ class ServerRequestWrapperFixture implements ServerRequestInterface
     public function __construct(ServerRequestInterface $request = null, callable $factory = null)
     {
         if (null !== $request) {
-            $this->setMessage($request);
+            $this->setWrapped($request);
         }
 
         if (null !== $factory) {

--- a/test/Fixture/StreamWrapperFixture.php
+++ b/test/Fixture/StreamWrapperFixture.php
@@ -12,7 +12,7 @@ class StreamWrapperFixture implements StreamInterface
     public function __construct(StreamInterface $stream = null)
     {
         if (null !== $stream) {
-            $this->setStream($stream);
+            $this->setWrapped($stream);
         }
     }
 }

--- a/test/Fixture/UploadedFileWrapperFixture.php
+++ b/test/Fixture/UploadedFileWrapperFixture.php
@@ -12,7 +12,7 @@ class UploadedFileWrapperFixture implements UploadedFileInterface
     public function __construct(UploadedFileInterface $file = null)
     {
         if (null !== $file) {
-            $this->setUploadedFile($file);
+            $this->setWrapped($file);
         }
     }
 }

--- a/test/Fixture/UriWrapperFixture.php
+++ b/test/Fixture/UriWrapperFixture.php
@@ -12,7 +12,7 @@ class UriWrapperFixture implements UriInterface
     public function __construct(UriInterface $uri = null, callable $factory = null)
     {
         if (null !== $uri) {
-            $this->setUri($uri);
+            $this->setWrapped($uri);
         }
 
         if (null !== $factory) {


### PR DESCRIPTION
Once #10 is merged, this cleans up the disparately named setter methods to `setWrapped()`.